### PR TITLE
(GH-8) New Rule for number of lines in scripts

### DIFF
--- a/src/chocolatey.package.validator/chocolatey.package.validator.csproj
+++ b/src/chocolatey.package.validator/chocolatey.package.validator.csproj
@@ -143,6 +143,7 @@
     <Compile Include="infrastructure.app\rules\ProjectSourceUrlDoesNotMatchProjectUrlGuideline.cs" />
     <Compile Include="infrastructure.app\rules\ProjectSourceUrlMissingSuggestion.cs" />
     <Compile Include="infrastructure.app\rules\ReleaseNotesNotEmptyGuideline.cs" />
+    <Compile Include="infrastructure.app\rules\ScriptsContainTooManyLinesGuideline.cs" />
     <Compile Include="infrastructure.app\rules\ScriptsDoNotContainChocoCommandsRequirement.cs" />
     <Compile Include="infrastructure.app\rules\ScriptsDoNotContainInternalVariablesRequirement.cs" />
     <Compile Include="infrastructure.app\rules\DescriptionRequirement.cs" />

--- a/src/chocolatey.package.validator/infrastructure.app/rules/ScriptsContainTooManyLinesGuideline.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/rules/ScriptsContainTooManyLinesGuideline.cs
@@ -1,0 +1,49 @@
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.package.validator.infrastructure.app.rules
+{
+    using System.IO;
+    using infrastructure.rules;
+    using NuGet;
+
+    public class ScriptsContainTooManyLinesGuideline : BasePackageRule
+    {
+        public override string ValidationFailureMessage { get { return "Chocolatey Packages are meant to be thin wrappers on top of the native installation packages, as a result, there is an expectation that the installation scripts will be less than 100 lines.  Can this script be simplified?"; } }
+
+        protected override PackageValidationOutput is_valid(IPackage package)
+        {
+            var valid = true;
+
+            var files = package.GetFiles().or_empty_list_if_null();
+            foreach (var packageFile in files)
+            {
+                string extension = Path.GetExtension(packageFile.Path).to_lower();
+                if (extension != ".ps1" && extension != ".psm1") continue;
+
+                var numberOfLines = 0;
+
+                using (var streamReader = new StreamReader(packageFile.GetStream()))
+                {
+                    while (streamReader.ReadLine() != null) numberOfLines++;
+                }
+
+                valid = numberOfLines < 100;
+            }
+
+            return valid;
+        }
+    }
+}


### PR DESCRIPTION
- Scripts should be less than 100 lines long
- Fixes GH-8