### PR TITLE
Fix #181

### DIFF
--- a/src/chocolatey.package.validator/infrastructure.app/rules/ScriptsShouldntUseInstallArgumentsRequirement.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/rules/ScriptsShouldntUseInstallArgumentsRequirement.cs
@@ -38,9 +38,9 @@ namespace chocolatey.package.validator.infrastructure.app.rules
             {
                 var contents = packageFile.Value.to_lower();
 
-                if (contents.Contains("installarguments") ||
-                    contents.Contains("installerarguments") ||
-                    contents.Contains("chocolateyinstallarguments"))
+                if (contents.Contains("$installarguments") ||
+                    contents.Contains("$installerarguments") ||
+                    contents.Contains("$chocolateyinstallarguments"))
                 {
                     valid = false;
                 }


### PR DESCRIPTION
Instead of using just words in the substring, prefix with `$` since we're targeting usage of the **variable**, not just anything with that string in it.