### PR TITLE
(GH-194) Add rule and tests for markdown headings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ src/packages
 
 *.suo
 *.sln.docstates
-*.user 
+*.user
 *.csproj.user
 *.[rR]esharper.user
 *.DotSettings.user
@@ -24,7 +24,7 @@ _ReSharper*
 *.pidb
 *userprefs
 *.nupkg
- 
+
 TestResult.xml
 submit.xml
 SolutionVersion.cs

--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ SolutionVersion.vb
 src/_dotCover*/
 src/_dotTrace*/
 src/chocolatey.sln.GhostDoc.xml
+
+.vs/

--- a/src/chocolatey.package.validator.tests/chocolatey.package.validator.tests.csproj
+++ b/src/chocolatey.package.validator.tests/chocolatey.package.validator.tests.csproj
@@ -89,6 +89,7 @@
     <Compile Include="infrastructure.app\BinariesAreIncludedNoteSpecs.cs" />
     <Compile Include="infrastructure.app\CopyrightAndAuthorFieldsShouldntContainEmailRequirementSpecs.cs" />
     <Compile Include="infrastructure.app\DependencyWithNoVersionGuidelineSpecs.cs" />
+    <Compile Include="infrastructure.app\DescriptionHeadingMarkdownRequirementSpecs.cs" />
     <Compile Include="infrastructure.app\DescriptionWordCountMinimum30GuidelineSpecs.cs" />
     <Compile Include="infrastructure.app\DescriptionWordCountMaximum4000RequirementSpecs.cs" />
     <Compile Include="infrastructure.app\IncludesChocolateyDependencyNoteSpecs.cs" />

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DescriptionHeadingMarkdownRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DescriptionHeadingMarkdownRequirementSpecs.cs
@@ -1,0 +1,426 @@
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.package.validator.tests.infrastructure.app
+{
+    using chocolatey.package.validator.infrastructure.app.rules;
+    using chocolatey.package.validator.infrastructure.rules;
+    using Moq;
+    using NuGet;
+    using Should;
+
+    public abstract class DescriptionHeadingMarkdownRequirementSpecsBase : TinySpec
+    {
+        protected DescriptionHeadingMarkdownRequirement requirement;
+        protected Mock<IPackage> package = new Mock<IPackage>();
+
+        public override void Context()
+        {
+            requirement = new DescriptionHeadingMarkdownRequirement();
+        }
+
+        public class when_inspecting_package_with_valid_markdown_heading_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"# Heading 1
+
+Stuff
+
+## Heading 2
+
+Stuff
+
+### Heading 3
+
+Stuff
+
+#### Heading 4
+
+Stuff
+
+##### Heading 5
+
+Stuff
+
+###### Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_be_valid()
+            {
+                result.Validated.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+        }
+
+        public class when_inspecting_package_with_no_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_be_valid()
+            {
+                result.Validated.ShouldBeTrue();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+        }
+
+        public class when_inspecting_package_with_invalid_markdown_heading_1_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"#Heading 1
+
+Stuff
+
+## Heading 2
+
+Stuff
+
+### Heading 3
+
+Stuff
+
+#### Heading 4
+
+Stuff
+
+##### Heading 5
+
+Stuff
+
+###### Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_not_be_valid()
+            {
+                result.Validated.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+
+        }
+
+        public class when_inspecting_package_with_invalid_markdown_heading_2_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"# Heading 1
+
+Stuff
+
+##Heading 2
+
+Stuff
+
+### Heading 3
+
+Stuff
+
+#### Heading 4
+
+Stuff
+
+##### Heading 5
+
+Stuff
+
+###### Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_not_be_valid()
+            {
+                result.Validated.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+
+        }
+
+        public class when_inspecting_package_with_invalid_markdown_heading_3_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"# Heading 1
+
+Stuff
+
+## Heading 2
+
+Stuff
+
+###Heading 3
+
+Stuff
+
+#### Heading 4
+
+Stuff
+
+##### Heading 5
+
+Stuff
+
+###### Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_not_be_valid()
+            {
+                result.Validated.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+
+        }
+
+        public class when_inspecting_package_with_invalid_markdown_heading_4_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"#Heading 1
+
+Stuff
+
+## Heading 2
+
+Stuff
+
+### Heading 3
+
+Stuff
+
+####Heading 4
+
+Stuff
+
+##### Heading 5
+
+Stuff
+
+###### Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_not_be_valid()
+            {
+                result.Validated.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+
+        }
+
+        public class when_inspecting_package_with_invalid_markdown_heading_5_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"# Heading 1
+
+Stuff
+
+## Heading 2
+
+Stuff
+
+### Heading 3
+
+Stuff
+
+#### Heading 4
+
+Stuff
+
+#####Heading 5
+
+Stuff
+
+###### Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_not_be_valid()
+            {
+                result.Validated.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+
+        }
+
+        public class when_inspecting_package_with_invalid_markdown_heading_6_in_description : DescriptionHeadingMarkdownRequirementSpecsBase
+        {
+            private PackageValidationOutput result;
+
+            public override void Context()
+            {
+                base.Context();
+
+                package.Setup(p => p.Description).Returns(@"# Heading 1
+
+Stuff
+
+## Heading 2
+
+Stuff
+
+### Heading 3
+
+Stuff
+
+#### Heading 4
+
+Stuff
+
+##### Heading 5
+
+Stuff
+
+######Heading 6
+
+Stuff");
+
+            }
+
+            public override void Because()
+            {
+                result = requirement.is_valid(package.Object);
+            }
+
+            [Fact]
+            public void should_not_be_valid()
+            {
+                result.Validated.ShouldBeFalse();
+            }
+
+            [Fact]
+            public void should_not_override_the_base_message()
+            {
+                result.ValidationFailureMessageOverride.ShouldBeNull();
+            }
+
+        }
+    }
+}

--- a/src/chocolatey.package.validator/chocolatey.package.validator.csproj
+++ b/src/chocolatey.package.validator/chocolatey.package.validator.csproj
@@ -134,6 +134,7 @@
     <Compile Include="infrastructure.app\messaging\PackageValidationResultMessage.cs" />
     <Compile Include="infrastructure.app\rules\AuthorDoesNotMatchMaintainerNote.cs" />
     <Compile Include="infrastructure.app\rules\BinariesAreIncludedNote.cs" />
+    <Compile Include="infrastructure.app\rules\DescriptionHeadingMarkdownRequirement.cs" />
     <Compile Include="infrastructure.app\rules\InstallScriptShouldNotCallUninstallScriptsRequirement.cs" />
     <Compile Include="infrastructure.app\rules\CommentsShouldBeCleanedUpRequirement.cs" />
     <Compile Include="infrastructure.app\rules\CopyrightAndAuthorFieldsShouldntContainEmailRequirement.cs" />

--- a/src/chocolatey.package.validator/infrastructure.app/rules/DescriptionHeadingMarkdownRequirement.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/rules/DescriptionHeadingMarkdownRequirement.cs
@@ -1,0 +1,47 @@
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+//
+// You may obtain a copy of the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+namespace chocolatey.package.validator.infrastructure.app.rules
+{
+    using System.Text.RegularExpressions;
+    using infrastructure.rules;
+    using NuGet;
+
+    public class DescriptionHeadingMarkdownRequirement : BasePackageRule
+    {
+        private const string HeadingRegexPattern = @"^(#+)([^\s#].*)$";
+
+        public override string ValidationFailureMessage
+        {
+            get
+            {
+                return
+@"Package Description should not contain invalid Markdown Headings. [More...](https://github.com/chocolatey/package-validator/wiki/DescriptionValidMarkdownHeading)";
+            }
+        }
+
+        public override PackageValidationOutput is_valid(IPackage package)
+        {
+            if (package.Description == null)
+            {
+                return true;
+            }
+
+            var regex = new Regex(HeadingRegexPattern, RegexOptions.Multiline);
+
+            return !regex.IsMatch(package.Description);
+        }
+    }
+}


### PR DESCRIPTION
To validate that any headings used within the Description field of the
nuspec file contains valid markdown syntax.  Before the update to the
chocolatey.org website, it would correctly render a heading that used:

#Heading 1

However, this is accurately against the markdown spec, and instead
should be written as follows:

# Heading 1

This new rule, will provide a Guideline in the package valdiator output
to suggest that the correct syntax be used.