### PR TITLE
(GH-200) Make SecurityProtocol changes immediately

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.BugTrackerUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_bug_tracker_url_that_requires_Useragent_header : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_bug_tracker_url_that_requires_tls_1_3 : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DescriptionUrlsShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DescriptionUrlsShouldBeValidRequirementSpecs.cs
@@ -240,4 +240,75 @@ You can host your own sources and add them to Chocolatey, you can extend Chocola
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_url_that_requires_Useragent_header : DescriptionUrlsShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.Description).Returns(@"
+This is a test description with a [url](https://hamapps.com/php/license.php) that requires a User Agent Header in order to work.
+");
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_url_that_requires_tls_1_3 : DescriptionUrlsShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.Description).Returns(@"
+This is a test description with a [url](https://talk.atomisystems.com/) that requires TLS 1.3 in the client.
+");
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.DocsUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_docs_url_that_requires_Useragent_header : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.DocsUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_docs_url_that_requires_tls_1_3 : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.DocsUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.DocsUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.DocsUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.IconUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.IconUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.IconUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_icon_url_that_requires_Useragent_header : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.IconUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_icon_url_that_requires_tls_1_3 : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.IconUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.LicenseUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.LicenseUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_license_url_that_requires_Useragent_header : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_license_url_that_requires_tls_1_3 : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.PackageSourceUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_package_source_url_that_requires_Useragent_header : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_package_source_url_that_requires_tls_1_3 : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_project_source_url_that_requires_Useragent_header : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_project_source_url_that_requires_tls_1_3 : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.ProjectUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_project_url_that_requires_Useragent_header : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_project_url_that_requires_tls_1_3 : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.ProjectUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ReleaseNotesUrlsShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ReleaseNotesUrlsShouldBeValidRequirementSpecs.cs
@@ -233,4 +233,75 @@ See all - http://github.com/chocolatey/choco/blob/stable/CHANGELOG.md
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_url_in_releasenotes_that_requires_Useragent_header : ReleaseNotesUrlsShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.ReleaseNotes).Returns(@"
+This is a test description with a [url](https://hamapps.com/php/license.php) that requires a User Agent Header in order to work.
+");
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_url_in_releasenotes_that_requires_tls_1_3 : ReleaseNotesUrlsShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.ReleaseNotes).Returns(@"
+This is a test description with a [url](https://talk.atomisystems.com/) that requires TLS 1.3 in the client.
+");
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -128,6 +128,73 @@ namespace chocolatey.package.validator.tests.infrastructure.app
 
             //This should redirect to https:// with a 301
             package.Setup(p => p.WikiUrl).Returns(new Uri("http://chocolatey.org"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_wiki_url_that_requires_Useragent_header : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.WikiUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_wiki_url_that_requires_tls_1_3 : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.WikiUrl).Returns(new Uri("https://talk.atomisystems.com/"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -1,4 +1,4 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
+// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.WikiUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.WikiUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -119,6 +119,7 @@ namespace chocolatey.package.validator.infrastructure.app.utility
             request.Timeout = 15000;
             //This would allow 301 and 302 to be valid as well
             request.AllowAutoRedirect = true;
+            request.UserAgent = "{0}/{1}".format_with(ApplicationParameters.Name, ApplicationParameters.FileVersion);
             try
             {
                 using (var response = (HttpWebResponse)request.GetResponse())

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -1,4 +1,4 @@
-// Copyright © 2015 - Present RealDimensions Software, LLC
+﻿// Copyright © 2015 - Present RealDimensions Software, LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -111,9 +111,11 @@ namespace chocolatey.package.validator.infrastructure.app.utility
         /// <param name="url">Uri object</param>
         public static bool url_is_valid(Uri url)
         {
-            var request = (HttpWebRequest)WebRequest.Create(url);
             // Use TLS1.2, TLS1.1, TLS1.0, SSLv3
             SecurityProtocol.set_protocol();
+
+            var request = (HttpWebRequest)WebRequest.Create(url);
+
             request.Timeout = 15000;
             //This would allow 301 and 302 to be valid as well
             request.AllowAutoRedirect = true;

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -1,12 +1,12 @@
-﻿// Copyright © 2015 - Present RealDimensions Software, LLC
-// 
+// Copyright © 2015 - Present RealDimensions Software, LLC
+//
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
-// 
+//
 // You may obtain a copy of the License at
-// 
+//
 // 	http://www.apache.org/licenses/LICENSE-2.0
-// 
+//
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -43,7 +43,7 @@ namespace chocolatey.package.validator.infrastructure.app.utility
                 {
                     var contents = packageFile.GetStream().ReadToEnd();
                     automationScripts.Add(packageFile, contents);
-                   
+
                     // add any PowerShell scripts that were referenced
                     try
                     {
@@ -100,7 +100,7 @@ namespace chocolatey.package.validator.infrastructure.app.utility
                     StringExtensions.to_lower(f.Path).EndsWith(".iso") ||
                     StringExtensions.to_lower(f.Path).EndsWith(".dmg") ||
                     StringExtensions.to_lower(f.Path).EndsWith(".so")  ||
-                    StringExtensions.to_lower(f.Path).EndsWith(".jar") 
+                    StringExtensions.to_lower(f.Path).EndsWith(".jar")
 
             );
         }
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.infrastructure.app.utility
             catch (WebException ex)
             {
                 "package-validator".Log().Warn("Error validating Url {0} - {1}", url.ToString(), ex.Message);
-                // TODO: Perhaps this function should return true if there is a website that does not work with our SSL/TLS settings. 
+                // TODO: Perhaps this function should return true if there is a website that does not work with our SSL/TLS settings.
                 return false;
             }
         }


### PR DESCRIPTION
Changes to the SecurityProtocolType should be made before creating any
request objects, otherwise those settings aren't applied to the request
object that already exists.

Relates to #200 