### PR TITLE
(GH-199) Only attempt to validate http/https URLs

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_bug_tracker_url_with_non_http_or_https_scheme : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_docs_url_with_non_http_or_https_scheme : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.DocsUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_icon_url_with_non_http_or_https_scheme : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.IconUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_license_url_with_non_http_or_https_scheme : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_package_source_url_with_non_http_or_https_scheme : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_project_source_url_with_non_http_or_https_scheme : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_project_url_with_non_http_or_https_scheme : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -214,4 +214,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_wiki_url_with_non_http_or_https_scheme : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.WikiUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -111,6 +111,17 @@ namespace chocolatey.package.validator.infrastructure.app.utility
         /// <param name="url">Uri object</param>
         public static bool url_is_valid(Uri url)
         {
+            if (url == null)
+            {
+                return true;
+            }
+
+            if (!url.Scheme.StartsWith("http"))
+            {
+                // Currently we can only validate http/https URL's, therefore simply return true for any others.
+                return true;
+            }
+
             // Use TLS1.2, TLS1.1, TLS1.0, SSLv3
             SecurityProtocol.set_protocol();
 


### PR DESCRIPTION
The Chocolatey nuspec file will accept any valid URI, however, we only
attempt want to attempt to validate http/https URL's.  This change
enforces this, and return true for any other type of URI.

Fixes #199 