### PR TITLE
(maint) Corrected spelling of underscores

### DIFF
--- a/src/chocolatey.package.validator/infrastructure.app/rules/PackageIdUsesUnderscoresNote.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/rules/PackageIdUsesUnderscoresNote.cs
@@ -25,7 +25,7 @@ namespace chocolatey.package.validator.infrastructure.app.rules
             get
             {
                 return
-@"The package id includes underscorse (_). Usually the package id is separated by '-' instead of underscores.  The reviewer will ensure this is not a new package. [More...](https://github.com/chocolatey/package-validator/wiki/PackageIdUsesUnderscores)";
+@"The package id includes underscores (_). Usually the package id is separated by '-' instead of underscores.  The reviewer will ensure this is not a new package. [More...](https://github.com/chocolatey/package-validator/wiki/PackageIdUsesUnderscores)";
             }
         }
 


### PR DESCRIPTION
The validation messages includes a spelling error with the
word 'underscorse' instead of the correct spelling of
'underscores'. This PR make the change to correct
the spelling mistake.