### PR TITLE
(GH-210) Add check for mailto scheme

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_bug_tracker_url : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_docs_url : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.DocsUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_icon_url : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.IconUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_license_url : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
@@ -147,4 +147,137 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052281
+    /// </summary>
+    public class when_inspecting_package_with_valid_mailing_list_url_that_requires_Useragent_header : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require UserAgent header, otherwise a 403 response is returned
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("https://hamapps.com/php/license.php"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// </summary>
+    public class when_inspecting_package_with_valid_mailing_list_url_that_requires_tls_1_3 : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // This URL should require TLS 1.3 on the client, otherwise it won't be able to establish a connection
+            // to the server
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("https://talk.atomisystems.com/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/199
+    /// </summary>
+    public class when_inspecting_package_with_valid_mailing_list_url_with_non_http_or_https_scheme : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // Non http/https URLs shouldn't be validated, and if passed in, should simply return true
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("git://git.code.sf.net/p/mrviewer/code"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_mailing_list_url : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
@@ -127,7 +127,7 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             base.Context();
 
             //This should redirect to https:// with a 301
-            package.Setup(p => p.MailingListUrl).Returns(new Uri("http://chocolatey.org")); 
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("http://chocolatey.org"));
         }
 
         public override void Because()

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_package_source_url : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_project_source_url : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_project_url : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -247,4 +247,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/210
+    /// </summary>
+    public class when_inspecting_package_with_mailto_scheme_in_wiki_url : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.WikiUrl).Returns(new Uri("mailto:someone@yoursite.com"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_invalid()
+        {
+            result.Validated.ShouldBeFalse();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -114,6 +114,12 @@ namespace chocolatey.package.validator.infrastructure.app.utility
                 return true;
             }
 
+            if (url.Scheme == "mailto")
+            {
+                // mailto links are not expected/allowed, therefore immediately fail with no further processing
+                return false;
+            }
+
             if (!url.Scheme.StartsWith("http"))
             {
                 // Currently we can only validate http/https URL's, therefore simply return true for any others.


### PR DESCRIPTION
If present in URL, fail validation.  A mailto link is not expected, and
therefore shouldn't be allowed.

Fixes #210 