### PR TITLE
(GH-212) Add CookieContainer to HttpWebRequest

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_bug_tracker_url_that_results_in_too_many_redirects : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_docs_url_that_results_in_too_many_redirects : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.DocsUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_icon_url_that_results_in_too_many_redirects : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.IconUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_license_url_that_results_in_too_many_redirects : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_mailing_list_url_that_results_in_too_many_redirects : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_package_source_url_that_results_in_too_many_redirects : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_project_source_url_that_results_in_too_many_redirects : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_project_url_that_results_in_too_many_redirects : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -280,4 +280,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/212
+    /// </summary>
+    public class when_inspecting_package_with_wiki_url_that_results_in_too_many_redirects : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.WikiUrl).Returns(new Uri("https://help.ea.com/en/origin/origin/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -129,7 +129,9 @@ namespace chocolatey.package.validator.infrastructure.app.utility
             try
             {
                 var request = (HttpWebRequest)WebRequest.Create(url);
+                var cookieContainer = new CookieContainer();
 
+                request.CookieContainer = cookieContainer;
                 request.Timeout = 15000;
                 //This would allow 301 and 302 to be valid as well
                 request.AllowAutoRedirect = true;


### PR DESCRIPTION
It is possible that an exception can be thrown when requesting a URL
which states "Too many automatic redirects were attempted".  It has
been found that this is caused due to there not being a CookieContainer
for the request in order to capture cookies that are sent with the
response.