### PR TITLE
(GH-214) Add accept header to request

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_bug_tracker_url_that_requires_accept_header : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_docs_url_that_requires_accept_header : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.DocsUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_icon_url_that_requires_accept_header : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.IconUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_license_url_that_requires_accept_header : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_mailing_list_url_that_requires_accept_header : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_package_source_url_that_requires_accept_header : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_project_source_url_that_requires_accept_header : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_project_url_that_requires_accept_header : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -313,4 +313,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/214
+    /// </summary>
+    public class when_inspecting_package_with_wiki_url_that_requires_accept_header : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.WikiUrl).Returns(new Uri("https://nbcgib.uesc.br/tinnr/en/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -136,6 +136,7 @@ namespace chocolatey.package.validator.infrastructure.app.utility
                 //This would allow 301 and 302 to be valid as well
                 request.AllowAutoRedirect = true;
                 request.UserAgent = "{0}/{1}".format_with(ApplicationParameters.Name, ApplicationParameters.FileVersion);
+                request.Accept = "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9";
 
                 using (var response = (HttpWebResponse)request.GetResponse())
                 {


### PR DESCRIPTION
Without the accept header, it was found that attempting to valid some
URL's was resulting in a 403 Forbidden response.  The Accept header used
here is the same as the header used within Fiddler when testing the URL
in question.

Fixes #214 