### PR TITLE
(GH-216) Add handling for specific error Status 

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_bug_tracker_url_that_requires_tls_1_3 : BugTrackerUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_bug_tracker_url_that_requires_newer_tls_cipher : BugTrackerUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DescriptionUrlsShouldBeValidGuidelineSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DescriptionUrlsShouldBeValidGuidelineSpecs.cs
@@ -277,9 +277,9 @@ This is a test description with a [url](https://hamapps.com/php/license.php) tha
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_url_that_requires_tls_1_3 : DescriptionUrlsShouldBeValidGuidelineSpecs
+    public class when_inspecting_package_with_valid_url_that_requires_newer_tls_cipher : DescriptionUrlsShouldBeValidGuidelineSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_docs_url_that_requires_tls_1_3 : DocsUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_docs_url_that_requires_newer_tls_cipher : DocsUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_icon_url_that_requires_tls_1_3 : IconUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_icon_url_that_requires_newer_tls_cipher : IconUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_license_url_that_requires_tls_1_3 : LicenseUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_license_url_that_requires_newer_tls_cipher : LicenseUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_mailing_list_url_that_requires_tls_1_3 : MailingListUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_mailing_list_url_that_requires_newer_tls_cipher : MailingListUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_package_source_url_that_requires_tls_1_3 : PackageSourceUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_package_source_url_that_requires_newer_tls_cipher : PackageSourceUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_project_source_url_that_requires_tls_1_3 : ProjectSourceUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_project_source_url_that_requires_newer_tls_cipher : ProjectSourceUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_project_url_that_requires_tls_1_3 : ProjectUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_project_url_that_requires_newer_tls_cipher : ProjectUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ReleaseNotesUrlsShouldBeValidGuidelineSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ReleaseNotesUrlsShouldBeValidGuidelineSpecs.cs
@@ -270,9 +270,9 @@ This is a test description with a [url](https://hamapps.com/php/license.php) tha
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_url_in_releasenotes_that_requires_tls_1_3 : ReleaseNotesUrlsShouldBeValidGuidelineSpecs
+    public class when_inspecting_package_with_valid_url_in_releasenotes_that_requires_newer_tls_cipher : ReleaseNotesUrlsShouldBeValidGuidelineSpecs
     {
         private PackageValidationOutput result;
 

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -182,9 +182,9 @@ namespace chocolatey.package.validator.tests.infrastructure.app
     }
 
     /// <summary>
-    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/200#issuecomment-570052562
+    /// This test case comes from a reported issue here: https://github.com/chocolatey/package-validator/issues/216
     /// </summary>
-    public class when_inspecting_package_with_valid_wiki_url_that_requires_tls_1_3 : WikiUrlShouldBeValidRequirementSpecs
+    public class when_inspecting_package_with_valid_wiki_url_that_requires_newer_tls_cipher : WikiUrlShouldBeValidRequirementSpecs
     {
         private PackageValidationOutput result;
 


### PR DESCRIPTION
Since we can't guarantee that all TLS Ciphers are available on current
package-validator infrastructure, if there is a TLS Channel failure,
assume that it is due to a missing cipher, and validate the URL.  Once
moved to new hardware, we can back out this change.

Fixes #216 