### PR TITLE
(GH-202) Add handling for Protocol error 

### DIFF
--- a/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/BugTrackerUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_bug_tracker_url_that_returns_protocol_error : BugTrackerUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.BugTrackerUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/DocsUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_docs_url_that_returns_protocol_error : DocsUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.DocsUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/IconUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_icon_url_that_returns_protocol_error : IconUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.IconUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/LicenseUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_license_url_that_returns_protocol_error : LicenseUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.LicenseUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/MailingListUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_mailing_list_url_that_returns_protocol_error : MailingListUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.MailingListUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/PackageSourceUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_package_source_url_that_returns_protocol_error : PackageSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.PackageSourceUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectSourceUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_project_source_url_that_returns_protocol_error : ProjectSourceUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectSourceUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/ProjectUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_project_url_that_returns_protocol_error : ProjectUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.ProjectUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
+++ b/src/chocolatey.package.validator.tests/infrastructure.app/WikiUrlShouldBeValidRequirementSpecs.cs
@@ -346,4 +346,37 @@ namespace chocolatey.package.validator.tests.infrastructure.app
             result.ValidationFailureMessageOverride.ShouldBeNull();
         }
     }
+
+    /// <summary>
+    /// This test case comes from issue here: https://github.com/chocolatey/package-validator/issues/202
+    /// </summary>
+    public class when_inspecting_package_with_wiki_url_that_returns_protocol_error : WikiUrlShouldBeValidRequirementSpecs
+    {
+        private PackageValidationOutput result;
+
+        public override void Context()
+        {
+            base.Context();
+
+            // mailto url shouldn't be allowed
+            package.Setup(p => p.WikiUrl).Returns(new Uri("https://trac.mpc-hc.org/"));
+        }
+
+        public override void Because()
+        {
+            result = validationCheck.is_valid(package.Object);
+        }
+
+        [Fact]
+        public void should_be_valid()
+        {
+            result.Validated.ShouldBeTrue();
+        }
+
+        [Fact]
+        public void should_not_override_the_base_message()
+        {
+            result.ValidationFailureMessageOverride.ShouldBeNull();
+        }
+    }
 }

--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -152,6 +152,13 @@ namespace chocolatey.package.validator.infrastructure.app.utility
                     return true;
                 }
 
+                if (ex.Status == WebExceptionStatus.ProtocolError && ex.Message == "The remote server returned an error: (503) Server Unavailable.")
+                {
+                    "package-validator".Log().Warn("Error validating Url {0} - {1}", url.ToString(), ex.Message);
+                    "package-validator".Log().Warn("This could be due to Cloudflare DDOS protection acting in front of the site, or another valid reason, as such, this URL will be marked as valid for the time being.");
+                    return true;
+                }
+
                 "package-validator".Log().Error("Error validating Url {0} - {1}", url.ToString(), ex.Message);
                 return false;
             }


### PR DESCRIPTION
There is an edge case where a valid URL returns a 503 error code, and
then moves to the site when loaded in the browser.  When loading from
the command line, this isn't handled.  Add a special case for this.
This isn't ideal, but likely not many URL's that are in this position.

Fixes #202 