### PR TITLE
(GH-254) Assume valid URL when response is 302

### DIFF
--- a/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
+++ b/src/chocolatey.package.validator/infrastructure.app/utility/Utility.cs
@@ -212,6 +212,13 @@ namespace chocolatey.package.validator.infrastructure.app.utility
                     return true;
                 }
 
+                if (response.StatusCode == HttpStatusCode.Redirect)
+                {
+                    "package-validator".Log().Warn("Received a 302 response (so assuming a valid URL) from the server when validating URL {0}", url.ToString());
+                    "package-validator".Log().Warn("This check was put in place as a result of this issue: https://github.com/chocolatey/package-validator/issues/254");
+                    return true;
+                }
+
                 return response.StatusCode == HttpStatusCode.OK;
             }
             catch (Exception ex)

--- a/testing/Package Validator URL checking.linq
+++ b/testing/Package Validator URL checking.linq
@@ -114,6 +114,12 @@ public static bool url_is_valid(string problem, Uri url)
 			return true;
 		}
 
+		if (response.StatusCode == System.Net.HttpStatusCode.Redirect)
+		{
+			Console.WriteLine("Received a 302 response from the server");
+			return true;
+		}
+		
 		return response.StatusCode == System.Net.HttpStatusCode.OK;
 	}
 	catch (Exception ex)


### PR DESCRIPTION
For some reason, the HttpClient isn't following a 302 response from the
server, but I think it is fair to assume that a 302 response means that
the URL is valid.

Fixes #254 