### PR TITLE
(GH-257) Remove config package dependency

### DIFF
--- a/nuget/chocolatey-package-validator-service.nuspec
+++ b/nuget/chocolatey-package-validator-service.nuspec
@@ -27,7 +27,6 @@ What does the validator check? See https://docs.chocolatey.org/en-us/community-r
     <tags>chocolatey-package-validator admin</tags>
     <dependencies>
       <dependency id="chocolatey.extension" version="2.0.3" />
-      <dependency id="chocolatey-package-validator-config" version="1.0.0" />
     </dependencies>
   </metadata>
   <files>


### PR DESCRIPTION
Remove the config package dependency.

There is no hurry to merge this or create a new version of the package.

Closes #257 